### PR TITLE
Scrollable error page

### DIFF
--- a/error-page.js
+++ b/error-page.js
@@ -9,7 +9,7 @@ if (overlay) {
 overlay = document.createElement('div');
 overlay.id = OVERLAY_ID;
 
-overlay.innerHTML = `<div style="background: black; opacity: 0.85; font-size: 16px; color: white; position: fixed; height: 100%; width: 100%; top: 0px; left: 0px; padding: 30px; font-family: Menlo, Consolas, monospace; z-index: 9999;">
+overlay.innerHTML = `<div style="background: black; opacity: 0.85; font-size: 16px; color: white; position: fixed; height: 100%; width: 100%; top: 0px; left: 0px; padding: 30px; font-family: Menlo, Consolas, monospace; z-index: 9999; overflow: auto;">
   <div>
     <div style="font-size: 18px; font-weight: bold; margin-top: 20px;">
       🚨 Elm Compiler Error

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parcel-transformer-elm",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
When the compiler produces a long list of messages, the overlay error div should scroll appropriately